### PR TITLE
make i18n compile with Nim 1.2.1

### DIFF
--- a/i18n.nim
+++ b/i18n.nim
@@ -67,7 +67,7 @@ import encodings
 import algorithm
 import streams
 import tables
-import private.plural
+import private/plural
 
 from math import nextPowerOfTwo
 
@@ -142,7 +142,7 @@ proc `==`(self, other: Catalogue): bool =
 template `??`(a, b: string): string =
     if a.len != 0: a else: b
 
-proc c_memchr(cstr: pointer, c: char, n: csize): pointer {.
+proc c_memchr(cstr: pointer, c: char, n: csize_t): pointer {.
        importc: "memchr", header: "<string.h>" .}
 
 
@@ -294,7 +294,7 @@ proc newCatalogue(domain: string; filename: string) : Catalogue =
     # first entry is MO file metadata
     var voffset = value_entries[0].offset.int
     var vlength = value_entries[0].length.int
-    let metadata = value_cache[voffset..< voffset + vlength]
+    let metadata = value_cache[voffset ..< voffset + vlength]
 
     # find charset
     let cpos = metadata.find("charset=") + 8 # len of "charset="
@@ -338,7 +338,7 @@ proc newCatalogue(domain: string; filename: string) : Catalogue =
         var vlength = value_entries[i].length.int
 
         # looks for NULL byte in key
-        var null_byte = c_memchr(result.key_cache[koffset].addr, '\0', klength)
+        var null_byte = c_memchr(result.key_cache[koffset].addr, '\0', klength.csize_t)
         if null_byte != nil: # key has plural
             let ksplit = cast[ByteAddress](null_byte) -% cast[ByteAddress](result.key_cache[0].addr)
 
@@ -350,7 +350,7 @@ proc newCatalogue(domain: string; filename: string) : Catalogue =
             var remaining = vlength
             var index = 0
             while true:
-                var null_byte = c_memchr(value_cache[voffset].addr, '\0', remaining + 1)
+                var null_byte = c_memchr(value_cache[voffset].addr, '\0', (remaining + 1).csize_t)
                 if null_byte == nil or remaining <= 0:
                     break
                 let vsplit = cast[ByteAddress](null_byte) -% cast[ByteAddress](value_cache[0].addr)

--- a/i18n.nimble
+++ b/i18n.nimble
@@ -1,6 +1,6 @@
 [Package]
 name          : "i18n"
-version       : "0.1.0"
+version       : "0.1.1"
 author        : "Parashurama"
 description   : "Bring a gettext-like internationalisation module to Nim"
 license       : "MIT"


### PR DESCRIPTION
I couldn't import nim-i18n into a current Nim (version 1.2.1); obviously a few things have changed meanwhile. Now it compiles, and translates strings in a test setup.

Disclaimer: I'm totally new to Nim and hope my changes are sensible!