### PR TITLE
prevent over-run from `plural=0\n` pattern.

### DIFF
--- a/private/plural.nim
+++ b/private/plural.nim
@@ -103,7 +103,7 @@ proc evaluate*(symbols: openArray[State]; value: int): int =
     result = stack.pop
 
 proc parse_constant(buf: string, pos: var int): int =
-    while buf[pos] in {'0'..'9'}:
+    while pos < len(buf) and buf[pos] in {'0'..'9'} :
         result = (result * 10) + (ord(buf[pos]) - ord('0'))
         inc(pos)
 


### PR DESCRIPTION
- index out of range exception will be cause with::

    `Plural-Forms: nplurals=1; plural=0`

    languages: Japanese, Vietnamese, Korean and Thai
    https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html#Plural-forms